### PR TITLE
Switch gallery to remote images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # Testing
 Experiments and Random Testing
+
+## Website
+
+`index.html` provides a small personal site for Gino Colombi. The page links to Spotify, Beatport and SoundCloud, and embeds players from both services. The photo gallery pulls images from remote URLs so no binary assets are stored in the repository.
+
+## HTML Validation
+
+This project may include HTML pages such as `index.html`. You can check for basic syntax issues using either the `tidy` utility or the `validate_html.py` script.
+
+### Using tidy
+
+Install tidy with:
+
+```
+sudo apt-get update
+sudo apt-get install -y tidy
+```
+
+Then run:
+
+```
+tidy -errors index.html
+```
+
+### Using the Python script
+
+Run the script with an optional filename. If no file is given it defaults to `index.html`:
+
+```
+python3 validate_html.py [file.html]
+```
+
+## Testing
+
+Run the validation command:
+
+```
+tidy -errors index.html
+# or
+python3 validate_html.py
+```
+
+## Previewing Locally
+
+You can preview the site in a browser without deploying it. From the repository root run:
+
+```
+python3 -m http.server
+```
+
+Then visit [http://localhost:8000/](http://localhost:8000/) in your browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Official home of underground house DJ & producer Gino Colombi. Listen to mixes, find releases, and get the latest news.">
+    <meta name="keywords" content="Gino Colombi, underground house, DJ, producer, mixes, releases">
+    <title>Gino Colombi - Underground House DJ & Producer</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="hero">
+        <h1>Gino Colombi</h1>
+        <p class="tagline">Underground House Music DJ &amp; Producer</p>
+    </header>
+    <nav>
+        <ul>
+            <li><a href="#about">About</a></li>
+            <li><a href="#releases">Releases</a></li>
+            <li><a href="#gallery">Gallery</a></li>
+            <li><a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA">Spotify</a></li>
+            <li><a href="https://www.beatport.com/artist/gino-colombi/1033866">Beatport</a></li>
+            <li><a href="http://soundcloud.com/GinoColombi">SoundCloud</a></li>
+            <li><a href="https://soundcloud.com/houseisliferecords">House Is Life Records</a></li>
+        </ul>
+    </nav>
+    <main class="container">
+        <section id="about">
+            <h2>About</h2>
+            <p>Gino Colombi brings an underground vibe to every dance floor. With deep grooves and infectious energy, his sets move crowds and keep them coming back for more. Follow Gino's journey on <a href="https://github.com/TestSubject-DJ">GitHub</a> for behind-the-scenes projects and playlists.</p>
+        </section>
+
+        <section id="releases">
+            <h2>Latest Releases</h2>
+            <p>Stream Gino's newest tracks on your preferred platform:</p>
+            <ul class="platform-links">
+                <li><a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA">Spotify</a></li>
+                <li><a href="https://www.beatport.com/artist/gino-colombi/1033866">Beatport</a></li>
+                <li><a href="http://soundcloud.com/GinoColombi">SoundCloud</a></li>
+            </ul>
+            <div class="embeds">
+                <iframe width="100%" height="166" scrolling="no" frameborder="0" allow="autoplay"
+                    src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/ginocolombi/lose-control-radio-edit&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true">
+                </iframe>
+
+                <iframe style="border-radius:12px"
+                    src="https://open.spotify.com/embed/album/6a3SXFGb3E82fHaamJ914Q?utm_source=generator"
+                    width="100%" height="380" frameborder="0" allowfullscreen=""
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy">
+                </iframe>
+            </div>
+        </section>
+
+        <section id="gallery">
+            <h2>Gallery</h2>
+            <div class="gallery">
+                <img src="https://images.unsplash.com/photo-1470225620780-dba8ba36b745?auto=format&fit=crop&w=800&q=80" alt="Gino Colombi Live">
+                <img src="https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=800&q=80" alt="DJ Setup">
+                <img src="https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=800&q=80" alt="Underground House Art">
+                <img src="https://images.unsplash.com/photo-1497493292307-31c376b6e479?auto=format&fit=crop&w=800&q=80" alt="90s House DJ Illustration">
+                <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=800&q=80" alt="Warehouse Party Vibe">
+                <img src="https://images.unsplash.com/photo-1485579149621-3123dd979885?auto=format&fit=crop&w=800&q=80" alt="Vinyl Motion Blur">
+                <img src="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=800&q=80" alt="Feel Down Artwork">
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2025 Gino Colombi</p>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,79 @@
+body {
+    font-family: 'Poppins', Arial, Helvetica, sans-serif;
+    background-color: #000;
+    color: #f8f8f8;
+    margin: 0;
+    padding: 0;
+}
+
+a {
+    color: #f8d800;
+    text-decoration: none;
+}
+
+header.hero {
+    background: #111;
+    color: #fff;
+    text-align: center;
+    padding: 2rem;
+}
+
+.tagline {
+    margin-top: 0.5rem;
+    font-style: italic;
+    color: #f8d800;
+}
+
+nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    list-style: none;
+    padding: 0.5rem;
+    margin: 0;
+    background: #111;
+}
+
+nav li {
+    margin: 0 1rem;
+}
+
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+section {
+    margin-bottom: 3rem;
+}
+
+.gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.gallery img {
+    max-width: 300px;
+    width: 100%;
+    height: auto;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background: #111;
+    color: #888;
+}
+
+.embeds {
+    margin-top: 1rem;
+}
+
+.embeds iframe {
+    width: 100%;
+    border: none;
+    margin-top: 0.5rem;
+}

--- a/validate_html.py
+++ b/validate_html.py
@@ -1,0 +1,56 @@
+from html.parser import HTMLParser
+import sys
+
+class ValidatingParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.errors = []
+
+    VOID_ELEMENTS = {
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+        'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+    }
+
+    def handle_starttag(self, tag, attrs):
+        if tag not in self.VOID_ELEMENTS:
+            self.stack.append((tag, self.getpos()))
+
+    def handle_endtag(self, tag):
+        if not self.stack:
+            self.errors.append(f"Unexpected closing tag </{tag}> at line {self.getpos()[0]}")
+            return
+        open_tag, pos = self.stack.pop()
+        if open_tag != tag:
+            self.errors.append(
+                f"Mismatched tag: opened <{open_tag}> at line {pos[0]} but closed </{tag}> at line {self.getpos()[0]}"
+            )
+
+    def close(self):
+        super().close()
+        while self.stack:
+            tag, pos = self.stack.pop()
+            self.errors.append(f"Unclosed tag <{tag}> opened at line {pos[0]}")
+
+
+def validate(filename: str) -> int:
+    parser = ValidatingParser()
+    try:
+        with open(filename, 'r') as f:
+            parser.feed(f.read())
+        parser.close()
+    except FileNotFoundError:
+        print(f"{filename} not found.")
+        return 1
+    if parser.errors:
+        print("Parse errors:")
+        for err in parser.errors:
+            print(" -", err)
+        return 1
+    else:
+        print("No parse errors found.")
+        return 0
+
+if __name__ == "__main__":
+    filename = sys.argv[1] if len(sys.argv) > 1 else "index.html"
+    sys.exit(validate(filename))


### PR DESCRIPTION
## Summary
- avoid binary assets by removing `images/` directory
- pull gallery photos from remote URLs
- document remote images in README

## Testing
- `python3 -m py_compile validate_html.py`
- `python3 validate_html.py`
- ❌ `tidy -errors index.html` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_684228b5e40c8325a205083a8d601f63