### PR TITLE
Split site sections into separate pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -57,10 +57,11 @@
         </ul>
     </nav>
     <main class="container">
-        <section id="home">
-            <h2>Welcome</h2>
-            <p>Explore mixes, releases and visuals from underground house DJ &amp; producer Gino Colombi.</p>
+        <section id="about">
+            <h2>About</h2>
+            <p>Gino Colombi is a genre-blending DJ &amp; producer pushing underground house forward with soul, energy and vinyl grit. Known for mixing Old School House, UKG, Tech House and Techno with trancey synths, jazzy organs and chopped vocals. His sets are dynamic and his productions speak to both nostalgia and innovation.</p>
         </section>
+
 
     </main>
     <footer>

--- a/gallery.html
+++ b/gallery.html
@@ -57,11 +57,25 @@
         </ul>
     </nav>
     <main class="container">
-        <section id="home">
-            <h2>Welcome</h2>
-            <p>Explore mixes, releases and visuals from underground house DJ &amp; producer Gino Colombi.</p>
-        </section>
 
+
+        <section id="gallery">
+            <h2>Gallery</h2>
+            <div class="gallery">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225059/999_ldyfix.jpg" alt="Nervous style graphic" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225059/GinoAtHome_ikgsl6.jpg" alt="Gino at home studio" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225059/90sHouse_wmieal.png" alt="90s house illustration" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225059/8twzqzfedacfl8yk1ju6i_zzbysx.jpg" alt="Candid DJ shot" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/out-0_zmw1om.png" alt="Bold club poster" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg" alt="Gino playing live" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/Setup_tv0ltg.jpg" alt="Turntable setup" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/9999_od0vbz.jpg" alt="Hand-drawn record art" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225061/Vinyl_m0fljs.jpg" alt="Vinyl collection" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225062/UndergroundHouse_aubn4a.png" alt="Underground house graphic" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225064/ChatGPT_Image_Apr_9_2025_08_31_20_PM_fowq04.png" alt="Abstract DJ art" loading="lazy">
+                <img class="hvr-grow" src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225068/Warehouse_gf3s7n.png" alt="Warehouse exterior" loading="lazy">
+            </div>
+        </section>
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>

--- a/releases.html
+++ b/releases.html
@@ -57,9 +57,29 @@
         </ul>
     </nav>
     <main class="container">
-        <section id="home">
-            <h2>Welcome</h2>
-            <p>Explore mixes, releases and visuals from underground house DJ &amp; producer Gino Colombi.</p>
+
+        <section id="releases">
+            <h2>Latest Releases</h2>
+            <ul>
+                <li>Keep It Real EP – Great Stuff Talents (2025-03-21)</li>
+                <li>My Essence EP – Late Night Munchies (2024-10-18)</li>
+                <li>Just Because – Soul Beach Records (2024-08-30)</li>
+                <li>Digital Waves – theBasement Discos (2023-07-14)</li>
+            </ul>
+            <p>Stream on your preferred platform:</p>
+            <ul class="platform-links">
+                <li><a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA" target="_blank" rel="noopener noreferrer">Spotify</a></li>
+                <li><a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank" rel="noopener noreferrer">Beatport</a></li>
+                <li><a href="https://soundcloud.com/GinoColombi" target="_blank" rel="noopener noreferrer">SoundCloud</a></li>
+            </ul>
+            <div class="embeds">
+                <iframe width="100%" height="300" scrolling="no" frameborder="no" sandbox="allow-same-origin allow-scripts allow-popups" allow="autoplay" referrerpolicy="no-referrer"
+                    src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/2092105026&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true&amp;visual=true">
+                </iframe>
+                <iframe style="border-radius:12px" src="https://open.spotify.com/embed/track/6FDtCG4klWV4T1h7SC7QJo?utm_source=generator" referrerpolicy="no-referrer"
+                    width="100%" height="352" frameborder="0" sandbox="allow-same-origin allow-scripts allow-popups" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy">
+                </iframe>
+            </div>
         </section>
 
     </main>


### PR DESCRIPTION
## Summary
- split index page into multiple pages for Home, About, Releases, and Gallery
- update navigation links across pages
- add HTML files for the new pages

## Testing
- `python3 validate_html.py index.html`
- `python3 validate_html.py about.html`
- `python3 validate_html.py releases.html`
- `python3 validate_html.py gallery.html`


------
https://chatgpt.com/codex/tasks/task_e_684329dfc8ac8325b1b37277ab9bb8e8