### PR TITLE
Add PayPal support component

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,17 @@
             <h2>Welcome</h2>
             <p>Explore mixes, releases and visuals from underground house DJ &amp; producer Gino Colombi.</p>
         </section>
-
+        <section class="paypal-support-card">
+          <p>
+            Show some love for your favourite artists.<br>
+            Follow this link to their own support page.
+            <a href="https://www.paypal.com/paypalme/GinoColombi" target="_blank">Learn more</a>
+          </p>
+          <a href="https://www.paypal.com/paypalme/GinoColombi" target="_blank" class="paypal-button">
+            💵 Support Gino Colombi
+          </a>
+        </section>
+        
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>

--- a/style.css
+++ b/style.css
@@ -123,3 +123,47 @@ footer {
         display: block;
     }
 }
+
+.paypal-support-card {
+    background: radial-gradient(circle at top left, #194375, #113c66);
+    color: white;
+    padding: 1.5rem;
+    border-radius: 12px;
+    max-width: 360px;
+    margin: 2rem auto;
+    font-family: system-ui, sans-serif;
+    text-align: center;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.paypal-support-card p {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+    color: #eaeaea;
+}
+
+.paypal-support-card a {
+    color: #cce3ff;
+    text-decoration: underline;
+}
+
+.paypal-button {
+    display: inline-block;
+    background-color: white;
+    color: black;
+    font-weight: 600;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    text-decoration: none;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    transition: all 0.2s ease-in-out;
+}
+
+.paypal-button:hover {
+    background-color: #f5f5f5;
+    box-shadow: 0 0 10px rgba(255,255,255,0.2);
+}


### PR DESCRIPTION
## Summary
- embed PayPal support card on the homepage
- style the PayPal card with a subtle theme while keeping PayPal colors

## Testing
- `python3 validate_html.py index.html`

------
https://chatgpt.com/codex/tasks/task_e_68432c43318c8325863bedc88960ae1e