### PR TITLE
Replace Instagram preview with Latest Post embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,11 @@
             <p>To see more detailed releases, mixes, and booking info, check the corresponding pages.</p>
         </section>
 
-        <section class="social-widget">
-            <h2>&#128248; Instagram Preview</h2>
-            <iframe src="https://snapwidget.com/embed/1043112" width="100%" height="400"></iframe>
+        <section class="instagram-embed">
+            <h2>&#128248; Latest Post</h2>
+            <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/kiefmusic/p/DKkZSOHAQBC/" data-instgrm-version="14" style="margin: 1rem auto; max-width: 540px; width: 100%; background: #111; border: 0;">
+            </blockquote>
+            <script async src="https://www.instagram.com/embed.js"></script>
         </section>
 
         <section class="paypal-support-card">


### PR DESCRIPTION
## Summary
- swap the instagram preview section for an embedded Latest Post on the homepage
- use HTTPS for the Instagram embed script

## Testing
- `python3 validate_html.py index.html`
- `tidy -errors index.html`


------
https://chatgpt.com/codex/tasks/task_e_6843476529b8832588527acb6df4179f