### PR TITLE
Fix Instagram embed link

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,7 @@
             <h2>&#128248; Latest Post</h2>
             <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/kiefmusic/p/DKkZSOHAQBC/" data-instgrm-version="14" style="margin: 1rem auto; max-width: 540px; width: 100%; background: #111; border: 0;">
             </blockquote>
-4axtv7-codex/replace-instagram-preview-with-latest-post-section
-            <script async src="//www.instagram.com/embed.js"></script>
+            <script async src="https://www.instagram.com/embed.js"></script>
         </section>
 
         <section class="paypal-support-card">


### PR DESCRIPTION
## Summary
- remove leftover placeholder text next to Instagram embed
- use https for the embed script

## Testing
- `python3 validate_html.py index.html`

------
https://chatgpt.com/codex/tasks/task_e_684349dfd10c8325b6e02ade0e519508