### PR TITLE
Add music embeds to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,17 @@
 
         </section>
 
+        <section class="embeds">
+            <iframe style="border-radius:12px" src="https://open.spotify.com/embed/artist/6HaKvR8UvKwViIaIpUPVJA?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+            <a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank" style="display: inline-flex; align-items: center; text-decoration: none; background: #000; padding: 10px 16px; border-radius: 8px;">
+              <img src="https://assets.beatport.com/assets/logos/beatport-logo-green-black.svg" alt="Beatport Logo" style="height: 24px; margin-right: 10px;">
+              <span style="color: #A6FF00; font-family: sans-serif; font-weight: bold;">Gino Colombi on Beatport</span>
+            </a>
+            <a href="https://soundcloud.com/ginocolombi" target="_blank" style="display: inline-flex; align-items: center; text-decoration: none; background-color: #ff5500; padding: 10px 16px; border-radius: 8px;">
+              <img src="https://upload.wikimedia.org/wikipedia/commons/e/e6/SoundCloud_icon.svg" alt="SoundCloud Logo" style="height: 24px; margin-right: 10px;">
+              <span style="color: white; font-family: sans-serif; font-weight: bold;">Gino Colombi on SoundCloud</span>
+            </a>
+        </section>
         <section class="paypal-support-card">
             <p>
               Show some love for your favourite artists.<br>


### PR DESCRIPTION
## Summary
- embed Spotify player and add Beatport/SoundCloud links below latest post section

## Testing
- `python3 validate_html.py index.html`

------
https://chatgpt.com/codex/tasks/task_e_68437d77ecdc8325a992b49b8be02c89