### PR TITLE
Add hero CTA and social widgets

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,14 +8,14 @@
     <meta name="keywords" content="Gino Colombi, underground house, DJ, producer, vinyl, releases, mixes">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://ginocolombi.com/">
-    <meta property="og:title" content="Gino Colombi - Underground House DJ &amp; Producer">
-    <meta property="og:description" content="Official home of underground house DJ and producer Gino Colombi. Explore releases, mixes and vinyl culture.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ginocolombi.com/">
-    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg">
-    <title>Gino Colombi - Underground House DJ & Producer</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <title>Gino Colombi - Underground House DJ & Producer</title>
+    <meta property="og:title" content="Gino Colombi – DJ & Producer" />
+    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg" />
+    <meta property="og:url" content="https://testsubject-dj.github.io/Testing/" />
+    <meta property="og:description" content="Underground house & garage from Buenos Aires to the world." />
     <script defer src="script.js"></script>
     <script type="application/ld+json">
     {
@@ -56,15 +56,34 @@
         </ul>
     </nav>
     <main class="container">
-        <section id="about">
-            <h2>About</h2>
-            <p>Gino Colombi is a genre-blending DJ &amp; producer pushing underground house forward with soul, energy and vinyl grit. Known for mixing Old School House, UKG, Tech House and Techno with trancey synths, jazzy organs and chopped vocals. His sets are dynamic and his productions speak to both nostalgia and innovation.</p>
+        <section id="about" class="about-section fade-in">
+            <div class="about-img">
+                <img src="https://res.cloudinary.com/dexemnogl/image/upload/v1749225059/GinoAtHome_ikgsl6.jpg" alt="Gino Colombi in the studio" loading="lazy">
+            </div>
+            <div class="about-text">
+                <h2>About</h2>
+                <p>Gino Colombi is a genre-blending DJ &amp; producer pushing underground house forward with soul, energy and vinyl grit. Known for mixing Old School House, UKG, Tech House and Techno with trancey synths, jazzy organs and chopped vocals. His sets are dynamic and his productions speak to both nostalgia and innovation.</p>
+                <p class="badge">Top 100 Jackin House – Traxsource</p>
+                <p class="badge">Supported by Late Night Munchies, Great Stuff Talents</p>
+            </div>
         </section>
 
 
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>
+        <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="releases.html">Releases</a>
+            <a href="gallery.html">Gallery</a>
+        </div>
+        <div class="social-icons">
+            <a href="https://instagram.com/gino.colombi" target="_blank"><i class="fab fa-instagram"></i></a>
+            <a href="https://soundcloud.com/GinoColombi" target="_blank"><i class="fab fa-soundcloud"></i></a>
+            <a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA" target="_blank"><i class="fab fa-spotify"></i></a>
+            <a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank"><i class="fas fa-record-vinyl"></i></a>
+        </div>
     </footer>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -8,14 +8,14 @@
     <meta name="keywords" content="Gino Colombi, underground house, DJ, producer, vinyl, releases, mixes">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://ginocolombi.com/">
-    <meta property="og:title" content="Gino Colombi - Underground House DJ &amp; Producer">
-    <meta property="og:description" content="Official home of underground house DJ and producer Gino Colombi. Explore releases, mixes and vinyl culture.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ginocolombi.com/">
-    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg">
-    <title>Gino Colombi - Underground House DJ & Producer</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <title>Gino Colombi - Underground House DJ & Producer</title>
+    <meta property="og:title" content="Gino Colombi – DJ & Producer" />
+    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg" />
+    <meta property="og:url" content="https://testsubject-dj.github.io/Testing/" />
+    <meta property="og:description" content="Underground house & garage from Buenos Aires to the world." />
     <script defer src="script.js"></script>
     <script type="application/ld+json">
     {
@@ -78,6 +78,18 @@
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>
+        <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="releases.html">Releases</a>
+            <a href="gallery.html">Gallery</a>
+        </div>
+        <div class="social-icons">
+            <a href="https://instagram.com/gino.colombi" target="_blank"><i class="fab fa-instagram"></i></a>
+            <a href="https://soundcloud.com/GinoColombi" target="_blank"><i class="fab fa-soundcloud"></i></a>
+            <a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA" target="_blank"><i class="fab fa-spotify"></i></a>
+            <a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank"><i class="fas fa-record-vinyl"></i></a>
+        </div>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
     <meta name="keywords" content="Gino Colombi, underground house, DJ, producer, vinyl, releases, mixes">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://ginocolombi.com/">
-    <meta property="og:title" content="Gino Colombi - Underground House DJ &amp; Producer">
-    <meta property="og:description" content="Official home of underground house DJ and producer Gino Colombi. Explore releases, mixes and vinyl culture.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ginocolombi.com/">
-    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg">
-    <title>Gino Colombi - Underground House DJ & Producer</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <title>Gino Colombi - Underground House DJ & Producer</title>
+    <meta property="og:title" content="Gino Colombi – DJ & Producer" />
+    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg" />
+    <meta property="og:url" content="https://testsubject-dj.github.io/Testing/" />
+    <meta property="og:description" content="Underground house & garage from Buenos Aires to the world." />
     <script defer src="script.js"></script>
     <script type="application/ld+json">
     {
@@ -40,6 +40,7 @@
         <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
         <h1>Gino Colombi</h1>
         <p class="tagline">House Is Life Records &mdash; Underground Culture</p>
+        <a class="cta-button" href="releases.html#releases">Listen Now</a>
     </header>
     <nav id="main-nav">
         <ul>
@@ -106,10 +107,28 @@
             💵 Support Gino Colombi
           </a>
         </section>
+        <section class="mailing-list fade-in">
+            <form action="https://your-mailing-list-provider.com" method="POST">
+              <input type="email" name="email" placeholder="Get exclusive tracks &amp; updates" required />
+              <button type="submit">Subscribe</button>
+            </form>
+        </section>
         
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>
+        <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="releases.html">Releases</a>
+            <a href="gallery.html">Gallery</a>
+        </div>
+        <div class="social-icons">
+            <a href="https://instagram.com/gino.colombi" target="_blank"><i class="fab fa-instagram"></i></a>
+            <a href="https://soundcloud.com/GinoColombi" target="_blank"><i class="fab fa-soundcloud"></i></a>
+            <a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA" target="_blank"><i class="fab fa-spotify"></i></a>
+            <a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank"><i class="fas fa-record-vinyl"></i></a>
+        </div>
     </footer>
 </body>
 </html>

--- a/releases.html
+++ b/releases.html
@@ -8,14 +8,14 @@
     <meta name="keywords" content="Gino Colombi, underground house, DJ, producer, vinyl, releases, mixes">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://ginocolombi.com/">
-    <meta property="og:title" content="Gino Colombi - Underground House DJ &amp; Producer">
-    <meta property="og:description" content="Official home of underground house DJ and producer Gino Colombi. Explore releases, mixes and vinyl culture.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://ginocolombi.com/">
-    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg">
-    <title>Gino Colombi - Underground House DJ & Producer</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/hover.css@2.3.2/css/hover-min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <title>Gino Colombi - Underground House DJ & Producer</title>
+    <meta property="og:title" content="Gino Colombi – DJ & Producer" />
+    <meta property="og:image" content="https://res.cloudinary.com/dexemnogl/image/upload/v1749225060/GinoPlaying_fdzr61.jpg" />
+    <meta property="og:url" content="https://testsubject-dj.github.io/Testing/" />
+    <meta property="og:description" content="Underground house & garage from Buenos Aires to the world." />
     <script defer src="script.js"></script>
     <script type="application/ld+json">
     {
@@ -59,6 +59,8 @@
 
         <section id="releases">
             <h2>Latest Releases</h2>
+            <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/ginocolombi"></iframe>
+            <iframe style="border-radius:12px" src="https://open.spotify.com/embed/artist/6HaKvR8UvKwViIaIpUPVJA" width="100%" height="152" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
             <div class="releases-grid">
                 <a class="release-card" href="https://www.beatport.com/release/lose-control-original-mix/5112722" target="_blank" rel="noopener noreferrer">
                     <img src="https://geo-media.beatport.com/image_size/1400x1400/1b99682d-381d-406f-a6f9-5e7a1c99543c.jpg" alt="Keep It Real EP cover art">
@@ -102,6 +104,18 @@
     </main>
     <footer>
         <p>&copy; 2025 Gino Colombi</p>
+        <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="releases.html">Releases</a>
+            <a href="gallery.html">Gallery</a>
+        </div>
+        <div class="social-icons">
+            <a href="https://instagram.com/gino.colombi" target="_blank"><i class="fab fa-instagram"></i></a>
+            <a href="https://soundcloud.com/GinoColombi" target="_blank"><i class="fab fa-soundcloud"></i></a>
+            <a href="https://open.spotify.com/artist/6HaKvR8UvKwViIaIpUPVJA" target="_blank"><i class="fab fa-spotify"></i></a>
+            <a href="https://www.beatport.com/artist/gino-colombi/1033866" target="_blank"><i class="fas fa-record-vinyl"></i></a>
+        </div>
     </footer>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -14,3 +14,29 @@ document.querySelectorAll('#main-nav a').forEach(link => {
     });
 });
 
+const sections = document.querySelectorAll('main section');
+const navLinks = document.querySelectorAll('#main-nav a');
+
+const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+        if (entry.isIntersecting) {
+            const id = entry.target.getAttribute('id');
+            navLinks.forEach(link => {
+                if (link.getAttribute('href').includes(id)) {
+                    link.classList.add('active');
+                } else {
+                    link.classList.remove('active');
+                }
+            });
+            entry.target.classList.add('visible');
+        }
+    });
+}, { threshold: 0.5 });
+
+sections.forEach(sec => {
+    if (sec.classList.contains('fade-in')) {
+        sec.classList.add('fade-in');
+    }
+    observer.observe(sec);
+});
+

--- a/style.css
+++ b/style.css
@@ -1,12 +1,13 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap");
 :root {
-    --bg-color: #111;
-    --accent-yellow: #ffe600;
+    --bg-color: #000;
+    --primary-color: #7ED957;
     --accent-pink: #f06;
     --text-color: #f2f2f2;
 }
 
 body {
-    font-family: system-ui, sans-serif;
+    font-family: 'Poppins', sans-serif;
     background-color: var(--bg-color);
     color: var(--text-color);
     margin: 0;
@@ -17,7 +18,7 @@ body {
 }
 
 a {
-    color: var(--accent-yellow);
+    color: var(--primary-color);
     text-decoration: none;
 }
 a:hover,
@@ -45,7 +46,7 @@ header.hero {
 
 header.hero h1 {
     font-size: clamp(2.5rem, 8vw, 4rem);
-    color: var(--accent-yellow);
+    color: var(--primary-color);
     text-shadow: 2px 2px 0 #000;
 }
 
@@ -55,8 +56,8 @@ header.hero h1 {
     top: 1rem;
     right: 1rem;
     background: transparent;
-    border: 2px solid var(--accent-yellow);
-    color: var(--accent-yellow);
+    border: 2px solid var(--primary-color);
+    color: var(--primary-color);
     font-size: 1.5rem;
     padding: 0.25rem 0.5rem;
     cursor: pointer;
@@ -65,9 +66,28 @@ header.hero h1 {
 .tagline {
     margin-top: 0.5rem;
     font-style: italic;
-    color: var(--accent-yellow);
+    color: var(--primary-color);
     font-family: 'Impact', 'Arial Black', system-ui, sans-serif;
     text-transform: uppercase;
+}
+.cta-button {
+    display: inline-block;
+    margin-top: 1rem;
+    background: var(--primary-color);
+    color: #000;
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    font-weight: 600;
+    transition: background 0.3s;
+}
+.cta-button:hover {
+    background: var(--accent-pink);
+}
+nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: #111;
 }
 
 nav ul {
@@ -78,7 +98,7 @@ nav ul {
     padding: 0.5rem;
     margin: 0;
     background: #111;
-    border-bottom: 3px solid var(--accent-yellow);
+    border-bottom: 3px solid var(--primary-color);
 }
 
 nav li {
@@ -87,6 +107,9 @@ nav li {
     text-transform: uppercase;
 }
 
+nav a.active {
+    border-bottom: 2px solid var(--primary-color);
+}
 .container {
     max-width: 1000px;
     margin: 0 auto;
@@ -94,6 +117,25 @@ nav li {
 }
 
 section {
+.about-section {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+}
+.about-section img {
+    width: 100%;
+    border-radius: 8px;
+}
+.badge {
+    font-weight: 600;
+    color: var(--primary-color);
+}
+@media (max-width: 700px) {
+    .about-section {
+        grid-template-columns: 1fr;
+    }
+}
     margin-bottom: 3rem;
     padding-bottom: 2rem;
     border-bottom: 1px solid var(--accent-pink);
@@ -116,9 +158,24 @@ footer {
     padding: 1rem;
     background: #111;
     color: var(--text-color);
-    border-top: 2px solid var(--accent-yellow);
+    border-top: 2px solid var(--primary-color);
 }
 
+.footer-links {
+    margin-top: 0.5rem;
+}
+.footer-links a {
+    margin: 0 0.5rem;
+    color: var(--text-color);
+}
+.social-icons a {
+    color: var(--primary-color);
+    margin: 0 0.25rem;
+    font-size: 1.2rem;
+}
+.social-icons a:hover {
+    color: var(--accent-pink);
+}
 .embeds {
     margin-top: 1rem;
 }
@@ -151,7 +208,7 @@ footer {
     border-radius: 8px;
     max-width: 380px;
     margin: 2rem auto;
-    font-family: system-ui, sans-serif;
+    font-family: 'Poppins', sans-serif;
     text-align: center;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
 }
@@ -170,7 +227,7 @@ footer {
 
 .paypal-button {
     display: inline-block;
-    background-color: var(--accent-yellow);
+    background-color: var(--primary-color);
     color: #000;
     font-weight: 600;
     border: none;
@@ -187,6 +244,15 @@ footer {
     background-color: var(--accent-pink);
     box-shadow: 0 0 10px rgba(255,255,255,0.4);
     color: #000;
+}
+.fade-in {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.fade-in.visible {
+    opacity: 1;
+    transform: translateY(0);
 }
 .releases-grid {
     display: grid;
@@ -233,10 +299,15 @@ footer {
 }
 
 .release-card h3 {
-    font-family: system-ui, sans-serif;
+    font-family: 'Poppins', sans-serif;
     font-weight: 700;
     margin: 0.75rem;
     color: var(--text-color);
     font-size: 1rem;
 }
 
+
+.mailing-list form { display:flex; gap:0.5rem; justify-content:center; margin-top:1rem; }
+.mailing-list input{padding:0.5rem;border-radius:4px;border:none;}
+.mailing-list button{background:var(--primary-color);color:#000;border:none;padding:0.5rem 1rem;border-radius:4px;cursor:pointer;font-weight:600;}
+.mailing-list button:hover{background:var(--accent-pink);}


### PR DESCRIPTION
## Summary
- add listen now button on hero
- build animated about section
- embed players on releases page
- include social footer links and icons
- style updates (Poppins font, sticky header, fade-in, CTA styles)

## Testing
- `tidy -q -e index.html`
- `tidy -q -e about.html`
- `tidy -q -e releases.html`
- `tidy -q -e gallery.html`


------
https://chatgpt.com/codex/tasks/task_e_68476dbfd1ec83258ec0fcca5fbd1628